### PR TITLE
Fix number of rounds for AURA_REN to trigger

### DIFF
--- a/newkf.cpp
+++ b/newkf.cpp
@@ -2845,20 +2845,16 @@ BResult calcBattle(const BStat& attacker, const BStat& defender, bool showDetail
     int roundCounter = 0;
     int lastSide = 0;
     int roundN[2] = { 0, 0 };
-    int renCounter = 3;
-    if (b[0].tAgi > b[1].tAgi && b[0].tAgi >= b[1].tAgi * 6)
-    {
-        renCounter = 4;
-    }
-    if (b[1].tAgi > b[0].tAgi && b[1].tAgi >= b[0].tAgi * 6)
-    {
-        renCounter = 4;
-    }
     for (int round = 1;; ++round)
     {
         int s = b[0].spdC >= b[1].spdC ? 0 : 1;
         b[s].spdC -= b[1 - s].spdC;
         b[1 - s].spdC = 0.0;
+        int renCounter = 3;
+        if (b[lastSide].tAgi > b[1 - lastSide].tAgi && b[lastSide].tAgi >= b[1 - lastSide].tAgi * 6)
+        {
+            renCounter = 4;
+        }
         if (roundCounter == renCounter && b[1 - lastSide].psvSkl & AURA_REN)
         {
             //b[lastSide].spdC = 0;


### PR DESCRIPTION
Number of rounds for AURA_REN to trigger will be increased from 3 to 4 only when the faster side's agi is five times higher than the slower side's, not if the slower side's agi is five times higher than the faster side's.

Fixes #19 .